### PR TITLE
fixed endless /about redirect

### DIFF
--- a/about.html
+++ b/about.html
@@ -2,10 +2,10 @@
 <html>
 	<head>
 		<title>About</title>
-		<meta http-equiv="REFRESH" content="0;url=/about">
+		<meta http-equiv="REFRESH" content="0;url=/about/">
 		<link rel="canonical" href="/about" />
 	</head>
 	<body>
-		This page has moved. You will be automatically redirected to its new location. If you aren't forwarded to the new page, <a href="/about">click here</a>.
+		This page has moved. You will be automatically redirected to its new location. If you aren't forwarded to the new page, <a href="/about/">click here</a>.
 	</body>
 </html>


### PR DESCRIPTION
http://transformap.co/about redirects to itself, but it seeems like it should actually go to the subdirectory http://transformap.co/about/ _(slash at the end)_

Edit: just noticed: same for /activities. probably all the navigation links should get updated as well